### PR TITLE
Add warn and info about virtualenv creation/reuse

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -6,5 +6,6 @@
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
+- [Lees de README in het Nederlands](README_nl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README_es.md
+++ b/README_es.md
@@ -38,7 +38,7 @@ This package for YunoHost used [django-yunohost-integration](https://github.com/
 
 ## Información para desarrolladores
 
-Por favor enviar sus correcciones a la [`branch testing`](https://github.com/YunoHost-Apps/django_example_ynh/tree/testing
+Por favor enviar sus correcciones a la [rama `testing`](https://github.com/YunoHost-Apps/django_example_ynh/tree/testing).
 
 Para probar la rama `testing`, sigue asÍ:
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -1,0 +1,51 @@
+<!--
+NB: Deze README is automatisch gegenereerd door <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Hij mag NIET handmatig aangepast worden.
+-->
+
+# Django Example voor Yunohost
+
+[![Integratieniveau](https://dash.yunohost.org/integration/django_example.svg)](https://ci-apps.yunohost.org/ci/apps/django_example/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/django_example.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/django_example.maintain.svg)
+
+[![Django Example met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=django_example)
+
+*[Deze README in een andere taal lezen.](./ALL_README.md)*
+
+> *Met dit pakket kun je Django Example snel en eenvoudig op een YunoHost-server installeren.*  
+> *Als je nog geen YunoHost hebt, lees dan [de installatiehandleiding](https://yunohost.org/install), om te zien hoe je 'm installeert.*
+
+## Overzicht
+
+[![tests](https://github.com/YunoHost-Apps/django_example_ynh/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/YunoHost-Apps/django_example_ynh/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/github/jedie/django_example_ynh/branch/main/graph/badge.svg)](https://app.codecov.io/github/jedie/django_example_ynh)
+[![django_example_ynh @ PyPi](https://img.shields.io/pypi/v/django_example_ynh?label=django_example_ynh%20%40%20PyPi)](https://pypi.org/project/django_example_ynh/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/django_example_ynh)](https://github.com/YunoHost-Apps/django_example_ynh/blob/main/pyproject.toml)
+[![License GPL-3.0-or-later](https://img.shields.io/pypi/l/django_example_ynh)](https://github.com/YunoHost-Apps/django_example_ynh/blob/main/LICENSE)
+
+Demo YunoHost Application to demonstrate the integration of a Django project under YunoHost.
+
+Pull requests welcome ;)
+
+This package for YunoHost used [django-yunohost-integration](https://github.com/YunoHost-Apps/django_yunohost_integration)
+
+
+**Geleverde versie:** 0.2.0~ynh3
+## Documentatie en bronnen
+
+- Upstream app codedepot: <https://github.com/jedie/django-example>
+- YunoHost-store: <https://apps.yunohost.org/app/django_example>
+- Meld een bug: <https://github.com/YunoHost-Apps/django_example_ynh/issues>
+
+## Ontwikkelaarsinformatie
+
+Stuur je pull request alsjeblieft naar de [`testing`-branch](https://github.com/YunoHost-Apps/django_example_ynh/tree/testing).
+
+Om de `testing`-branch uit te proberen, ga als volgt te werk:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/django_example_ynh/tree/testing --debug
+of
+sudo yunohost app upgrade django_example -u https://github.com/YunoHost-Apps/django_example_ynh/tree/testing --debug
+```
+
+**Verdere informatie over app-packaging:** <https://yunohost.org/packaging_apps>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ applied_migrations = [
     "fad909d", # 2023-08-22T19:20:34+02:00
     "4abd4c0", # 2023-11-25T15:59:31+01:00
     "6fa011a", # 2024-09-07T11:11:40+02:00
+    "935485b", # 2024-09-09T10:39:39+02:00
 ]
 
 [manageprojects.cookiecutter_context.cookiecutter]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -57,23 +57,32 @@ myynh_install_python() {
 #==================================================================================
 #==================================================================================
 
+myynh_create_venv() {
+    local venv_flag=$1
+
+    # Create a virtualenv with python installed by myynh_install_python():
+    ynh_exec_as_app $py_app_version -m venv $venv_flag --upgrade-deps "$data_dir/.venv"
+
+    # Print some version information:
+    ynh_print_info "venv Python version: $($data_dir/.venv/bin/python3 -VV)"
+    ynh_print_info "venv Pip version: $($data_dir/.venv/bin/python3 -m pip -V)"
+
+    ynh_print_info "Install $app dependencies in virtualenv..."
+    ynh_exec_as_app $data_dir/.venv/bin/pip3 install --upgrade pip pip-tools wheel setuptools
+    ynh_exec_as_app $data_dir/.venv/bin/pip-sync --no-config "$data_dir/requirements.txt"
+}
+
 myynh_setup_python_venv() {
     # Install Python if needed:
     myynh_install_python
 
     ynh_print_info "Create Python virtualenv for $app..."
 
-    # Create a virtualenv with python installed by myynh_install_python():
-    # Skip pip because of: https://github.com/YunoHost/issues/issues/1960
-    ynh_exec_as_app $py_app_version -m venv --clear --upgrade-deps "$data_dir/.venv"
-
-	# Print some version information:
-	ynh_print_info "venv Python version: $($data_dir/.venv/bin/python3 -VV)"
-	ynh_print_info "venv Pip version: $($data_dir/.venv/bin/python3 -m pip -V)"
-
-    ynh_print_info "Install $app dependencies in virtualenv..."
-    ynh_exec_as_app $data_dir/.venv/bin/pip3 install --upgrade pip wheel setuptools
-    ynh_exec_as_app $data_dir/.venv/bin/pip3 install --no-deps -r "$data_dir/requirements.txt"
+    # Try to reuse existing venv (call without --clear flag)
+    if ! myynh_create_venv ""; then
+        # If there was an error: Recreate the venv by call with --clear flag
+        myynh_create_venv "--clear"
+    fi
 }
 
 myynh_setup_log_file() {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -81,7 +81,10 @@ myynh_setup_python_venv() {
     # Try to reuse existing venv (call without --clear flag)
     if ! myynh_create_venv ""; then
         # If there was an error: Recreate the venv by call with --clear flag
+        ynh_print_warn "Recreate $app virtualenv..."
         myynh_create_venv "--clear"
+    else
+        ynh_print_info "Existing $app virtualenv reused, ok."
     fi
 }
 


### PR DESCRIPTION
## Problem

- [Apply manageprojects updates](https://github.com/YunoHost-Apps/django_example_ynh/commit/3e2f44eb31d9fb6a502ed8907c5c9a85067cbcb1)
- [Add warn and info about virtualenv creation/reuse](https://github.com/YunoHost-Apps/django_example_ynh/commit/ab238698518c2eac6c7c361545b87c6d73d0b1a2)

## Solution

- *And how do you fix that problem*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
